### PR TITLE
connect knodes

### DIFF
--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -1,2 +1,0 @@
-# Operation Index
-

--- a/docs/build/index.md
+++ b/docs/build/index.md
@@ -1,0 +1,2 @@
+# Operation Index
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,5 +12,6 @@
 - [overlay](./overlay.md)
 - [overlay_compute_jaccard](./overlay_compute_jaccard.md)
 - [overlay_compute_ngd](./overlay_compute_ngd.md)
+- [overlay_connect_knodes](./overlay_connect_knodes.md)
 - [overlay_fisher_exact_test](./overlay_fisher_exact_test.md)
 - [restate](./restate.md)

--- a/docs/overlay_connect_knodes.md
+++ b/docs/overlay_connect_knodes.md
@@ -1,0 +1,28 @@
+# Overlay connect knodes
+
+_subclass of [overlay](./overlay.md)_
+
+Given a TRAPI message, create new kedges between existing knodes.  These may be created using arbitrary methods or data sources, though provenance should be attached to the new kedges.   Each new kedge is also added to all results containing node bindings to both the subject and object knodes.  This may be independent of any qedge connections, i.e. kedges can be created between any nodes in the kgraph.
+
+### examples
+
+- [input](../examples/overlay/messages/13_input_connectknodes.json), [output](../examples/overlay/messages/14_output_connectknodes.json)
+
+### input requirements
+
+None
+
+### output guarantees
+
+None
+
+### allowed changes
+
+- add kedges
+- add bindings to results
+
+### parameters
+
+```yaml
+{}
+```

--- a/examples/overlay/messages/13_input_connectknodes.json
+++ b/examples/overlay/messages/13_input_connectknodes.json
@@ -1,0 +1,66 @@
+{
+    "query_graph": {
+        "nodes": {
+            "type-2 diabetes": {
+                "id": "DOID:9352"
+            },
+            "protein": {
+                "category": "biolink:Protein"
+            },
+            "drug": {
+                "category": "biolink:ChemicalSubstance"
+            }
+        },
+        "edges": {
+            "associated": {
+                "subject": "protein",
+                "predicate": "biolink:gene_associated_with_condition",
+                "object": "type-2 diabetes"
+            },
+            "interacts": {
+                "subject": "protein",
+                "predicate": "biolink:physically_interacts_with",
+                "object": "drug"
+            }
+        }
+    },
+    "knowledge_graph": {
+        "nodes": {
+            "UniProtKB:P20823": {
+                "name": "HNF1A",
+                "category": "biolink:Protein"
+            },
+            "CHEMBL.COMPOUND:CHEMBL783": {
+                "name": "NATEGLINIDE",
+                "category": "biolink:ChemicalSubstance"
+            },
+            "DOID:9352": {"name": "type-2 diabetes"}
+        },
+        "edges": {
+            "df87ff82": {
+                "subject": "UniProtKB:P20823",
+                "predicate": "biolink:gene_associated_with_condition",
+                "object": "DOID:9352"
+            },
+            "vg56hkj9": {
+                "subject": "UniProtKB:P20823",
+                "predicate": "biolink:physically_interacts_with",
+                "object": "CHEMBL.COMPOUND:CHEMBL783"
+            }
+        }
+    },
+    "results": [
+        {
+            "node_bindings": {
+                "protein": [{"id": "UniProtKB:P20823"}],
+                "drug": [{"id": "CHEMBL.COMPOUND:CHEMBL783"}],
+                "type-2 diabetes": [{"id": "DOID:9352"}]
+            },
+            "edge_bindings": {
+                "associated": [{"id": "df87ff82"}],
+                "interacts": [{"id": "vg56hkj9"}]
+            }
+        }
+    ]
+}
+

--- a/examples/overlay/messages/14_output_connectknodes.json
+++ b/examples/overlay/messages/14_output_connectknodes.json
@@ -64,7 +64,7 @@
             "edge_bindings": {
                 "associated": [{"id": "df87ff82"}],
                 "interacts": [{"id": "vg56hkj9"}],
-                "_loose_binding_1": [{"id":"_support_edge_1"}]
+                "": [{"id":"_support_edge_1"}]
             }
         }
     ]

--- a/examples/overlay/messages/14_output_connectknodes.json
+++ b/examples/overlay/messages/14_output_connectknodes.json
@@ -46,7 +46,7 @@
                 "subject": "UniProtKB:P20823",
                 "predicate": "biolink:physically_interacts_with",
                 "object": "CHEMBL.COMPOUND:CHEMBL783"
-            }
+            },
             "_support_edge_1": {
                 "subject": "DOID:9352",
                 "object": "CHEMBL.COMPOUND:CHEMBL783",

--- a/examples/overlay/messages/14_output_connectknodes.json
+++ b/examples/overlay/messages/14_output_connectknodes.json
@@ -63,7 +63,7 @@
             },
             "edge_bindings": {
                 "associated": [{"id": "df87ff82"}],
-                "interacts": [{"id": "vg56hkj9"}]
+                "interacts": [{"id": "vg56hkj9"}],
                 "_loose_binding_1": [{"id":"_support_edge_1"}]
             }
         }

--- a/examples/overlay/messages/14_output_connectknodes.json
+++ b/examples/overlay/messages/14_output_connectknodes.json
@@ -1,0 +1,71 @@
+{
+    "query_graph": {
+        "nodes": {
+            "type-2 diabetes": {
+                "id": "DOID:9352"
+            },
+            "protein": {
+                "category": "biolink:Protein"
+            },
+            "drug": {
+                "category": "biolink:ChemicalSubstance"
+            }
+        },
+        "edges": {
+            "associated": {
+                "subject": "protein",
+                "predicate": "biolink:gene_associated_with_condition",
+                "object": "type-2 diabetes"
+            },
+            "interacts": {
+                "subject": "protein",
+                "predicate": "biolink:physically_interacts_with",
+                "object": "drug"
+            }
+        }
+    },
+    "knowledge_graph": {
+        "nodes": {
+            "UniProtKB:P20823": {
+                "name": "HNF1A",
+                "category": "biolink:Protein"
+            },
+            "CHEMBL.COMPOUND:CHEMBL783": {
+                "name": "NATEGLINIDE",
+                "category": "biolink:ChemicalSubstance"
+            },
+            "DOID:9352": {"name": "type-2 diabetes"}
+        },
+        "edges": {
+            "df87ff82": {
+                "subject": "UniProtKB:P20823",
+                "predicate": "biolink:gene_associated_with_condition",
+                "object": "DOID:9352"
+            },
+            "vg56hkj9": {
+                "subject": "UniProtKB:P20823",
+                "predicate": "biolink:physically_interacts_with",
+                "object": "CHEMBL.COMPOUND:CHEMBL783"
+            }
+            "_support_edge_1": {
+                "subject": "DOID:9352",
+                "object": "CHEMBL.COMPOUND:CHEMBL783",
+                "predicate": "biolink:correlated_with"
+            }
+        }
+    },
+    "results": [
+        {
+            "node_bindings": {
+                "protein": [{"id": "UniProtKB:P20823"}],
+                "drug": [{"id": "CHEMBL.COMPOUND:CHEMBL783"}],
+                "type-2 diabetes": [{"id": "DOID:9352"}]
+            },
+            "edge_bindings": {
+                "associated": [{"id": "df87ff82"}],
+                "interacts": [{"id": "vg56hkj9"}]
+                "_loose_binding_1": [{"id":"_support_edge_1"}]
+            }
+        }
+    ]
+}

--- a/operations/README.md
+++ b/operations/README.md
@@ -71,7 +71,6 @@
 ## general message formatting requirements
 
 - **no orphaned edges**: The `subject` and `object` for all qedges and kedges MUST map to qnode and knode keys, respectively.
-- **no orphaned bindings**: Each binding MUST map a knode or kedge key to a qnode or qedge key, respectively.
 - **[optional] unbound things**: There MAY be un-bound qnodes, qedges, knodes, and/or kedges.
 - **unique query graph ids**: All qnode and qedge keys MUST be unique within the qgraph.
 - **unique knowledge graph ids**: All knode and kedge keys MUST be unique globally. i.e. the same id should not be used to refer to two distinct kedges, even in response to two completely distinct queries.

--- a/operations/README.md
+++ b/operations/README.md
@@ -71,6 +71,7 @@
 ## general message formatting requirements
 
 - **no orphaned edges**: The `subject` and `object` for all qedges and kedges MUST map to qnode and knode keys, respectively.
+- **no orphaned bindings**: Each binding MUST map a knode or kedge key to a qnode or qedge key, respectively OR map a knode or kedge key to the key `""` (the empty string).
 - **[optional] unbound things**: There MAY be un-bound qnodes, qedges, knodes, and/or kedges.
 - **unique query graph ids**: All qnode and qedge keys MUST be unique within the qgraph.
 - **unique knowledge graph ids**: All knode and kedge keys MUST be unique globally. i.e. the same id should not be used to refer to two distinct kedges, even in response to two completely distinct queries.

--- a/operations/overlay_connect_knodes.yml
+++ b/operations/overlay_connect_knodes.yml
@@ -11,4 +11,4 @@ allowed_changes:
   - add kedges
   - add bindings to results
 
-parameters: []
+parameters: {}

--- a/operations/overlay_connect_knodes.yml
+++ b/operations/overlay_connect_knodes.yml
@@ -1,0 +1,14 @@
+id: overlay_connect_knodes
+subclass_of: overlay
+name: Overlay connect knodes
+description: Given a TRAPI message, create new kedges between existing knodes.  These may be created using arbitrary methods or data sources, though provenance should be attached to the new kedges.   Each new kedge is also added to all results containing node bindings to both the subject and object knodes.  This may be independent of any qedge connections, i.e. kedges can be created between any nodes in the kgraph.
+examples: 
+  - input: overlay/messages/13_input_connectknodes.json
+    output: overlay/messages/14_output_connectknodes.json
+input_requirements: []
+output_guarantees: []
+allowed_changes:
+  - add kedges
+  - add bindings to results
+
+parameters: []

--- a/schema/operation.json
+++ b/schema/operation.json
@@ -39,6 +39,9 @@
             "$ref": "#/$defs/OperationOverlayComputeNgd"
         },
         {
+            "$ref": "#/$defs/OperationOverlayConnectKnodes"
+        },
+        {
             "$ref": "#/$defs/OperationOverlayFisherExactTest"
         },
         {
@@ -386,6 +389,22 @@
             "required": [
                 "id",
                 "parameters"
+            ],
+            "additionalProperties": false
+        },
+        "OperationOverlayConnectKnodes": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "enum": [
+                        "overlay_connect_knodes"
+                    ]
+                },
+                "parameters": {}
+            },
+            "required": [
+                "id"
             ],
             "additionalProperties": false
         },


### PR DESCRIPTION
Adding an operation that is an overlay connecting knodes & updating bindings.

This is modeled following the way that aragorn adds literature co-occurrence edges.  One difference between this operation and others is that aragorn is not modifying the qgraph in any way, leading to keys in the edge bindings that do not correspond to a qgraph edge. 

So I also modified the rules to allow this :) 