### PR TITLE
Fixing schema $id tagging to 1.3.4

### DIFF
--- a/schema/operation.json
+++ b/schema/operation.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://standards.ncats.io/operation/1.3.3/schema",
+    "$id": "https://standards.ncats.io/operation/1.3.4/schema",
     "anyOf": [
         {
             "$ref": "#/$defs/OperationAnnotate"

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://standards.ncats.io/workflow/1.3.2/schema",
+    "$id": "https://standards.ncats.io/workflow/1.3.4/schema",
     "type": "array",
     "items": {
-        "$ref": "https://standards.ncats.io/operation/1.3.2/schema"
+        "$ref": "https://standards.ncats.io/operation/1.3.4/schema"
     }
 }


### PR DESCRIPTION
The Git released files for v1.3.4 didn't update the $id fields in the two 'workflow' and 'operations' schemata files. This PR does this.
If the existing v1.3.4 release cannot be fully patched in situ, then fix the three schema identifier URI's to 1.3.5 then release the project as v1.3.5 (suggest that the flawed releases are removed from Git and otherwise deprecated in other contexts)